### PR TITLE
Styling for sectioned lists, issue #1

### DIFF
--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -35,8 +35,8 @@
     <svg viewBox="0 0 85 80"><use xlink:href="#va-seal"></use></svg>
   </header>
   <section>
-    <ul class="checklist">
-
+    <ul class="checklist sectioned-list">
+      <h2 class="numbered-section numbered-section-start">Scheduling your appointment</h2>
       <li>Contact the Help Desk right away to let them know your tablet has arrived. They will conduct a test to make sure that everything works properly
         <ul>
           <li>National Telehealth Technology Help Desk 1-866-651-3180<br>
@@ -54,6 +54,7 @@
           <li>If you need to change or cancel your appointment, contact your scheduler at the number above.</li>
         </ul>
       </li>
+      <h2 class="numbered-section">Using your tablet</h2>
       <li>Familiarize yourself with the tablet. Please refer to the <em>Instructions for Tablet</em> document that comes with your tablet.</li>
       <li>Familiarize yourself with the applications (software) on the tablet. The VA applications you need for Telehealth have been pre-loaded. No other applications can be added to the tablet.</li>
     </ul>

--- a/source/stylesheets/style.css.scss
+++ b/source/stylesheets/style.css.scss
@@ -67,6 +67,55 @@ ul {
   }
 }
 
+$numbered-section-size: 1.5em;
+.numbered-section {
+  font-family: $sans;
+  color: $primary-color;
+  font-size: 1.2em;
+  position: relative;
+  text-transform: uppercase;
+  letter-spacing: .08em;
+  &:before {
+    content: counter(numbered-section);
+    border: 2px solid;
+    background-color: #fff;
+    border-radius: 50%;
+    width: $numbered-section-size;
+    height: $numbered-section-size;
+    position: absolute;
+    left: (($numbered-section-size * -1) - 1em);
+    top: (($numbered-section-size - 1em) / -2);
+    line-height: $numbered-section-size;
+    text-align: center;
+    letter-spacing: 0;
+    counter-increment: numbered-section;
+  }
+  &-start {
+    counter-reset: numbered-section;
+  }
+  @media print {
+    color: inherit;
+    font-size: 12pt;
+  }
+}
+
+.sectioned-list {
+  position: relative;
+  &:before {
+    content: '';
+    position: absolute;
+    width: 2px;
+    background-color: $primary-color;
+    top: .5em;
+    bottom: 0;
+    left: 1px;
+    @media print {
+      background-color: currentColor;
+      left: 10pt;
+    }
+  }
+}
+
 .hidden {
   display: none;
 }
@@ -134,6 +183,9 @@ ul {
   @media print {
     input[type='checkbox'] {
       display: none;
+    }
+    > li {
+      margin-left: 3em;
     }
     > li:before {
       content: '☐';


### PR DESCRIPTION
This adds styling for sectioned lists that are numbered as outlined in issue #1.

To use this add the class `sectioned-list` to the `ul` element, and then use headings with the class `numbered-section` within the list. To reset the numbering, add the class `numbered-section-start` to the first item in the list. It is best practice to do on every list, not just lists that come later in the document.